### PR TITLE
Initialize React apps for project areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # cercleLOLLY
+
+Ce dépôt contient trois applications React indépendantes initialisées avec Vite :
+
+- `client`
+- `conseillere`
+- `admin`
+
+Chaque dossier dispose de sa propre configuration et d'une page d'accueil accessible via React Router.

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "admin",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -1,0 +1,17 @@
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home.jsx'
+
+function App() {
+  return (
+    <Router>
+      <nav>
+        <Link to="/">Accueil</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </Router>
+  )
+}
+
+export default App

--- a/admin/src/main.jsx
+++ b/admin/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/admin/src/pages/Home.jsx
+++ b/admin/src/pages/Home.jsx
@@ -1,0 +1,5 @@
+function Home() {
+  return <h1>Accueil Admin</h1>
+}
+
+export default Home

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Client</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "client",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0"
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,17 @@
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home.jsx'
+
+function App() {
+  return (
+    <Router>
+      <nav>
+        <Link to="/">Accueil</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </Router>
+  )
+}
+
+export default App

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,0 +1,5 @@
+function Home() {
+  return <h1>Accueil Client</h1>
+}
+
+export default Home

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/conseillere/index.html
+++ b/conseillere/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Conseillere</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/conseillere/package.json
+++ b/conseillere/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "conseillere",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/conseillere/src/App.jsx
+++ b/conseillere/src/App.jsx
@@ -1,0 +1,17 @@
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home.jsx'
+
+function App() {
+  return (
+    <Router>
+      <nav>
+        <Link to="/">Accueil</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </Router>
+  )
+}
+
+export default App

--- a/conseillere/src/main.jsx
+++ b/conseillere/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/conseillere/src/pages/Home.jsx
+++ b/conseillere/src/pages/Home.jsx
@@ -1,0 +1,5 @@
+function Home() {
+  return <h1>Accueil Conseillère</h1>
+}
+
+export default Home

--- a/conseillere/vite.config.js
+++ b/conseillere/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold React applications with Vite for `client`, `conseillere` and `admin`
- add simple routing with React Router
- update README with project info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886ec2f8310832bb68b7e3b545f8a0d